### PR TITLE
Add script removal callback

### DIFF
--- a/hidiffusion/raunet.py
+++ b/hidiffusion/raunet.py
@@ -173,7 +173,7 @@ def apply_monkeypatch():
     unet.Upsample = HDUpsample
     unet.Downsample = HDDownsample
     unet.apply_control = hd_apply_control
-    logging.info("** jankhidiffusion: Apply  UNet monkey patches")
+    print("\x1b[32m[HiDiffusion]\x1b[0m Apply UNet monkey patches")
 
 
 def remove_monkeypatch():
@@ -181,7 +181,7 @@ def remove_monkeypatch():
     unet.Upsample = ORIG_UPSAMPLE
     unet.Downsample = ORIG_DOWNSAMPLE
     unet.apply_control = ORIG_APPLY_CONTROL
-    logging.info("** jankhidiffusion: Remove UNet monkey patches")
+    print("\x1b[32m[HiDiffusion]\x1b[0m Remove UNet monkey patches")
 
 
 def apply_rau_net(

--- a/hidiffusion/raunet.py
+++ b/hidiffusion/raunet.py
@@ -100,33 +100,31 @@ class HDDownsample(ORIG_DOWNSAMPLE):
 
 
 # Create proxy classes that inherit from original UNet classes
-class ProxyUpsample(ORIG_UPSAMPLE):
+class ProxyUpsample(HDUpsample):
+    """Proxy class that can switch between HD and original upsampling implementations."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.orig_instance = ORIG_UPSAMPLE(*args, **kwargs)
-        self.hd_instance = HDUpsample(*args, **kwargs)
         # Transfer weights and parameters
-        self.hd_instance.conv = self.conv
         self.orig_instance.conv = self.conv
         
     def forward(self, *args, **kwargs):
         if HDCONFIG.enabled:
-            return self.hd_instance.forward(*args, **kwargs)
+            return super().forward(*args, **kwargs)
         return self.orig_instance.forward(*args, **kwargs)
     
 
-class ProxyDownsample(ORIG_DOWNSAMPLE):
+class ProxyDownsample(HDDownsample):
+    """Proxy class that can switch between HD and original downsampling implementations."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.orig_instance = ORIG_DOWNSAMPLE(*args, **kwargs)
-        self.hd_instance = HDDownsample(*args, **kwargs)
         # Transfer weights and parameters
-        self.hd_instance.op = self.op
         self.orig_instance.op = self.op
         
     def forward(self, *args, **kwargs):
         if HDCONFIG.enabled:
-            return self.hd_instance.forward(*args, **kwargs)
+            return super().forward(*args, **kwargs)
         return self.orig_instance.forward(*args, **kwargs)
         
 

--- a/hidiffusion/raunet.py
+++ b/hidiffusion/raunet.py
@@ -370,13 +370,13 @@ def apply_rau_net_simple(enabled, model_type, res_mode, upscale_mode, ca_upscale
     enabled, blocks, ca_blocks, time_range, ca_time_range = configure_blocks(model_type, res)
 
     if not enabled:
-        logging.debug("** ApplyRAUNetSimple: Disabled")
+        logger.debug("** ApplyRAUNetSimple: Disabled")
         return (model.clone(),)
 
     prettyblocks = " / ".join(b if b else "none" for b in blocks)
     prettycablocks = " / ".join(b if b else "none" for b in ca_blocks)
 
-    logging.debug(
+    logger.debug(
         f"""** ApplyRAUNetSimple: Using preset {model_type} {res}:
         upscale: {upscale_mode}
         in/out blocks: [{prettyblocks}]

--- a/scripts/hidiffusion.py
+++ b/scripts/hidiffusion.py
@@ -1,26 +1,22 @@
-import logging
-
 import gradio as gr
 from backend.patcher.unet import UnetPatcher
 from modules import scripts
 from modules.script_callbacks import remove_current_script_callbacks
 
 # Now import from your package
-from hidiffusion.raunet import apply_monkeypatch, remove_monkeypatch, apply_rau_net, apply_rau_net_simple, UPSCALE_METHODS
+from hidiffusion.raunet import apply_unet_patches, remove_unet_patches, apply_rau_net, apply_rau_net_simple, UPSCALE_METHODS
 from hidiffusion.attention import apply_mswmsaa_attention, apply_mswmsaa_attention_simple
-
-logging.basicConfig(level=logging.INFO)
-logging.info("Imports successful in RAUNet script")
+from hidiffusion.logger import logger
 
 
-print("\x1b[32m[HiDiffusion] Script Loaded\x1b[0m")
+logger.info("Script Loaded")
 
 
 class RAUNetScript(scripts.Script):
     sorting_priority = 15  # Adjust this as needed
 
     def title(self):
-        return "Hidiffusion"
+        return "HiDiffusion"
 
     def show(self, is_img2img):
         return scripts.AlwaysVisible
@@ -124,7 +120,7 @@ class RAUNetScript(scripts.Script):
         enabled: bool = script_args[0]
 
         if enabled:
-            apply_monkeypatch()
+            apply_unet_patches()
             print("\x1b[32mRAUNet script enabled\x1b[0m")
 
         
@@ -219,12 +215,12 @@ class RAUNetScript(scripts.Script):
         # Always update the unet
         p.sd_model.forge_objects.unet = unet
 
-        # Add debug logging
-        logging.debug(f"RAUNet Simple enabled: {raunet_simple_enabled}, Model Type: {raunet_simple_model_type}")
-        logging.debug(f"RAUNet enabled: {raunet_enabled}, Model Type: {raunet_model_type}")
-        logging.debug(f"MSW-MSA Simple enabled: {mswmsa_simple_enabled}, Model Type: {mswmsa_simple_model_type}")
-        logging.debug(f"MSW-MSA enabled: {mswmsa_enabled}, Model Type: {mswmsa_model_type}")
-        logging.debug(f"MSW-MSA settings: Input Blocks: {mswmsa_input_blocks}, Output Blocks: {mswmsa_output_blocks}")
+        # Add debug logger
+        logger.debug(f"RAUNet Simple enabled: {raunet_simple_enabled}, Model Type: {raunet_simple_model_type}")
+        logger.debug(f"RAUNet enabled: {raunet_enabled}, Model Type: {raunet_model_type}")
+        logger.debug(f"MSW-MSA Simple enabled: {mswmsa_simple_enabled}, Model Type: {mswmsa_simple_model_type}")
+        logger.debug(f"MSW-MSA enabled: {mswmsa_enabled}, Model Type: {mswmsa_model_type}")
+        logger.debug(f"MSW-MSA settings: Input Blocks: {mswmsa_input_blocks}, Output Blocks: {mswmsa_output_blocks}")
 
         return
     
@@ -232,5 +228,5 @@ class RAUNetScript(scripts.Script):
     def postprocess(self, p, processed, *args):
         enabled: bool = args[0]
         if enabled:
-            remove_monkeypatch()
+            remove_unet_patches()
         remove_current_script_callbacks()

--- a/scripts/hidiffusion.py
+++ b/scripts/hidiffusion.py
@@ -3,6 +3,7 @@ import logging
 import gradio as gr
 from backend.patcher.unet import UnetPatcher
 from modules import scripts
+from modules.script_callbacks import remove_current_script_callbacks
 
 # Now import from your package
 from hidiffusion.raunet import apply_rau_net, apply_rau_net_simple, UPSCALE_METHODS
@@ -244,3 +245,7 @@ class RAUNetScript(scripts.Script):
         logging.debug(f"MSW-MSA settings: Input Blocks: {mswmsa_input_blocks}, Output Blocks: {mswmsa_output_blocks}")
 
         return
+    
+
+    def postprocess(self, p, processed, *args):
+        remove_current_script_callbacks()

--- a/scripts/hidiffusion.py
+++ b/scripts/hidiffusion.py
@@ -13,6 +13,9 @@ logging.basicConfig(level=logging.INFO)
 logging.info("Imports successful in RAUNet script")
 
 
+print("\x1b[32m[HiDiffusion] Script Loaded\x1b[0m")
+
+
 class RAUNetScript(scripts.Script):
     sorting_priority = 15  # Adjust this as needed
 
@@ -115,14 +118,14 @@ class RAUNetScript(scripts.Script):
                 mswmsa_simple_enabled, mswmsa_simple_model_type,
                 mswmsa_enabled, mswmsa_model_type, mswmsa_input_blocks, mswmsa_middle_blocks, mswmsa_output_blocks, 
                 mswmsa_time_mode, mswmsa_start_time, mswmsa_end_time)
-    
+
 
     def before_process(self, p, *script_args):
         enabled: bool = script_args[0]
 
         if enabled:
             apply_monkeypatch()
-            logging.info("\x1b[32mRAUNet script enabled\x1b[0m")
+            print("\x1b[32mRAUNet script enabled\x1b[0m")
 
         
     def process_before_every_sampling(self, p, *script_args, **kwargs):
@@ -227,5 +230,7 @@ class RAUNetScript(scripts.Script):
     
 
     def postprocess(self, p, processed, *args):
-        remove_monkeypatch()
+        enabled: bool = args[0]
+        if enabled:
+            remove_monkeypatch()
         remove_current_script_callbacks()

--- a/scripts/hidiffusion.py
+++ b/scripts/hidiffusion.py
@@ -6,15 +6,15 @@ from modules import scripts
 from modules.script_callbacks import remove_current_script_callbacks
 
 # Now import from your package
-from hidiffusion.raunet import apply_rau_net, apply_rau_net_simple, UPSCALE_METHODS
+from hidiffusion.raunet import apply_monkeypatch, remove_monkeypatch, apply_rau_net, apply_rau_net_simple, UPSCALE_METHODS
 from hidiffusion.attention import apply_mswmsaa_attention, apply_mswmsaa_attention_simple
 
+logging.basicConfig(level=logging.INFO)
 logging.info("Imports successful in RAUNet script")
 
 
 class RAUNetScript(scripts.Script):
     sorting_priority = 15  # Adjust this as needed
-    is_patched = False
 
     def title(self):
         return "Hidiffusion"
@@ -118,14 +118,10 @@ class RAUNetScript(scripts.Script):
     
 
     def before_process(self, p, *script_args):
-        (enabled,raunet_simple_enabled, raunet_simple_model_type, res_mode, simple_upscale_mode, simple_ca_upscale_mode,
-        raunet_enabled, raunet_model_type, input_blocks, output_blocks, time_mode, start_time, end_time, 
-        skip_two_stage_upscale, upscale_mode, ca_start_time, ca_end_time, ca_input_blocks, ca_output_blocks, ca_upscale_mode,
-        mswmsa_simple_enabled, mswmsa_simple_model_type,
-        mswmsa_enabled, mswmsa_model_type, mswmsa_input_blocks, mswmsa_middle_blocks, mswmsa_output_blocks, 
-        mswmsa_time_mode, mswmsa_start_time, mswmsa_end_time) = script_args
+        enabled: bool = script_args[0]
 
-        if enabled: 
+        if enabled:
+            apply_monkeypatch()
             logging.info("\x1b[32mRAUNet script enabled\x1b[0m")
 
         
@@ -140,25 +136,8 @@ class RAUNetScript(scripts.Script):
         # Always start with a fresh clone of the original unet
         unet = p.sd_model.forge_objects.unet.clone()
 
-        if not enabled:
-            if not RAUNetScript.is_patched:
-                return
-            
-            logging.info("\x1b[32mRAUNet script disabled, resetting modifications\x1b[0m")
-
-            # Apply RAUNet patch with enabled=False to reset any modifications
-            unet = apply_rau_net(False, unet, "", "", "", 0, 0, False, "", 0, 0, "", "", "")[0]
-            unet = apply_rau_net_simple(False, raunet_simple_model_type, res_mode, simple_upscale_mode, simple_ca_upscale_mode, unet)[0]
-
-            # Apply MSW-MSA patch with empty block settings to reset any modifications
-            unet = apply_mswmsaa_attention(unet, "", "", "", mswmsa_time_mode, 0, 0)[0]
-            unet = apply_mswmsaa_attention_simple(mswmsa_simple_model_type, unet)[0]
-
-            p.sd_model.forge_objects.unet = unet
-            RAUNetScript.is_patched = False
+        if not enabled:            
             return
-        
-        RAUNetScript.is_patched = True
 
         # Handle RAUNet
         if raunet_simple_enabled == True:  # Explicit check for True
@@ -248,4 +227,5 @@ class RAUNetScript(scripts.Script):
     
 
     def postprocess(self, p, processed, *args):
+        remove_monkeypatch()
         remove_current_script_callbacks()


### PR DESCRIPTION
Attempts to resolve jankiness of disabling the script after being used in a previous generation. Currently, You need to manually disable all parts of the script for it to remove its affect, however, the script is still processed when disabled which requires "unpatching" the model by applying empty block/attn patches.