### PR TITLE
Add manual unpatching button

### DIFF
--- a/scripts/forge_hidiffusion.py
+++ b/scripts/forge_hidiffusion.py
@@ -172,6 +172,11 @@ class ForgeHiDiffusion(scripts.Script):
                 "Compatibility: These methods may not work with other attention modifications or scaling effects targeting the same blocks."
             )
 
+            unpatch_button = gr.Button(
+                    value="Remove HiDiffusion Patches",
+                    info="Use this if HiDiffusion appears 'stuck' even after disabling the extension")
+            unpatch_button.click(fn=remove_unet_patches)
+
         # Add JavaScript to handle visibility and model-specific settings
         def update_raunet_settings(model_type):
             if model_type == "SD 1.5/2.1":


### PR DESCRIPTION
Adds a button to manually unpatch HiDiffusion from the UNet. Patches can get stuck at times if there is an Error during the generation and then the extension is disabled.